### PR TITLE
Loosen eslint rules.

### DIFF
--- a/js/eslint/via.json
+++ b/js/eslint/via.json
@@ -14,21 +14,118 @@
         },
         "sourceType": "module"
     },
+    "globals": {
+        "_": true
+    },
     "plugins": [
         "react"
     ],
     "rules": {
+        "curly": [
+            2,
+            "all"
+        ],
+        "operator-linebreak": [
+            2,
+            "after"
+        ],
         "indent": [
-            "error",
-            4
+            2,
+            4,
+            {
+                "SwitchCase": 1
+            }
         ],
-        "linebreak-style": [
-            "error",
-            "unix"
+        "no-multi-str": 2,
+        "no-mixed-spaces-and-tabs": 2,
+        "no-trailing-spaces": 2,
+        "space-unary-ops": [
+            2,
+            {
+                "nonwords": false,
+                "overrides": {}
+            }
         ],
-        "semi": [
-            "error",
+        "one-var": [
+            2,
+            "never"
+        ],
+        "brace-style": [
+            2,
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
+        ],
+        "keyword-spacing": [
+            2,
+            {
+                "overrides": {
+                    "else": {
+                        "before": true
+                    },
+                    "while": {
+                        "before": true
+                    },
+                    "catch": {
+                        "before": true
+                    }
+                }
+            }
+        ],
+        "padded-blocks": [
+            2,
+            "never"
+        ],
+        "space-infix-ops": 2,
+        "space-before-blocks": [
+            2,
             "always"
-        ]
+        ],
+        "key-spacing": [
+            2,
+            {
+                "afterColon": true
+            }
+        ],
+        "comma-spacing": [
+            2,
+            {
+                "after": true
+            }
+        ],
+        "eol-last": 2,
+        "space-before-function-paren": [
+            2,
+            {
+                "anonymous": "ignore",
+                "named": "never"
+            }
+        ],
+        "array-bracket-spacing": [
+            2,
+            "never",
+            {}
+        ],
+        "space-in-parens": [
+            2,
+            "never"
+        ],
+        "comma-dangle": [
+            2,
+            "never"
+        ],
+        "yoda": [
+            2,
+            "never"
+        ],
+        "no-empty": [
+            2,
+            {
+                "allowEmptyCatch": true
+            }
+        ],
+        "no-unused-vars": 0,
+        "no-undef": 0
     }
 }


### PR DESCRIPTION
This more closely matches our rules for jscs and works for both vanilla JS and JSX

The base was created using the Polyjuice tool from http://eslint.org/docs/user-guide/migrating-from-jscs.

There are a few other tweaks to get closer to our previous standard.