### PR TITLE
Remove comma-dangle rule

### DIFF
--- a/js/eslint/via.json
+++ b/js/eslint/via.json
@@ -91,10 +91,6 @@
       2,
       "never"
     ],
-    "comma-dangle": [
-      2,
-      "ignore"
-    ],
     "yoda": [
       2,
       "never"


### PR DESCRIPTION
This optionally allows dangling commas in JS